### PR TITLE
Fix get_spreadsheet_info 400 error from spaced fields param

### DIFF
--- a/src/claude_google_sheets/tools/drive_tools.py
+++ b/src/claude_google_sheets/tools/drive_tools.py
@@ -315,7 +315,7 @@ class GetSpreadsheetInfoHandler(SheetsToolHandler):
             sheets_info = (
                 sheets_service.spreadsheets()
                 .get(
-                    spreadsheetId=spreadsheet_id, fields="properties, sheets.properties"
+                    spreadsheetId=spreadsheet_id, fields="properties,sheets.properties"
                 )
                 .execute()
             )


### PR DESCRIPTION
## Summary
- `get_spreadsheet_info` always failed with a 400 \"Request contains an invalid argument\" error when calling the Sheets API.
- Root cause: the Drive API's `fields` parameter tolerates a space after commas (`\"id, name, ...\"` works fine), but the Sheets API's `fields` parser does not — `\"properties, sheets.properties\"` is parsed with a literal leading space before `sheets.properties`, which matches no field path.
- Fix: remove the space so it reads `\"properties,sheets.properties\"`.

## Test plan
- [x] Reproduced the 400 error directly via `sheets_service.spreadsheets().get(..., fields=\"properties, sheets.properties\")`
- [x] Confirmed the fixed `fields=\"properties,sheets.properties\"` call succeeds and returns sheet titles
- [x] Ran `get_spreadsheet_info` end-to-end through the MCP server after the fix — returns full spreadsheet metadata including all sheet tabs